### PR TITLE
Fix model construct

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "workflowai"
-version = "0.6.0.dev19"
+version = "0.6.0.dev20"
 description = ""
 authors = ["Guillaume Aquilina <guillaume@workflowai.com>"]
 readme = "README.md"

--- a/tests/integration/run_test.py
+++ b/tests/integration/run_test.py
@@ -77,11 +77,11 @@ async def test_stream_task_run(test_client: IntTestClient) -> None:
     task_input = CityToCapitalTaskInput(city="Hello")
     chunks = [chunk async for chunk in city_to_capital(task_input)]
 
-    assert chunks == [
-        CityToCapitalTaskOutput(capital=""),
-        CityToCapitalTaskOutput(capital="Tok"),
-        CityToCapitalTaskOutput(capital="Tokyo"),
-        CityToCapitalTaskOutput(capital="Tokyo"),
+    assert [chunk.capital for chunk in chunks] == [
+        "",
+        "Tok",
+        "Tokyo",
+        "Tokyo",
     ]
 
 
@@ -94,11 +94,11 @@ async def test_stream_task_run_custom_id(test_client: IntTestClient) -> None:
     task_input = CityToCapitalTaskInput(city="Hello")
     chunks = [chunk async for chunk in city_to_capital(task_input)]
 
-    assert chunks == [
-        CityToCapitalTaskOutput(capital=""),
-        CityToCapitalTaskOutput(capital="Tok"),
-        CityToCapitalTaskOutput(capital="Tokyo"),
-        CityToCapitalTaskOutput(capital="Tokyo"),
+    assert [chunk.capital for chunk in chunks] == [
+        "",
+        "Tok",
+        "Tokyo",
+        "Tokyo",
     ]
 
 

--- a/workflowai/core/_common_types.py
+++ b/workflowai/core/_common_types.py
@@ -19,7 +19,18 @@ AgentOutputCov = TypeVar("AgentOutputCov", bound=BaseModel, covariant=True)
 
 
 class OutputValidator(Protocol, Generic[AgentOutputCov]):
-    def __call__(self, data: dict[str, Any], has_tool_call_requests: bool) -> AgentOutputCov: ...
+    def __call__(self, data: dict[str, Any], partial: bool) -> AgentOutputCov:
+        """A way to convert a json object into an AgentOutput
+
+        Args:
+            data (dict[str, Any]): The json object to convert
+            partial (bool): Whether the json is partial, meaning that
+            it may not contain all the fields required by the AgentOutput model.
+
+        Returns:
+            AgentOutputCov: The converted AgentOutput
+        """
+        ...
 
 
 class VersionRunParams(TypedDict):

--- a/workflowai/core/client/_api.py
+++ b/workflowai/core/client/_api.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from typing import Any, Literal, Optional, TypeVar, Union, overload
@@ -6,13 +5,12 @@ from typing import Any, Literal, Optional, TypeVar, Union, overload
 import httpx
 from pydantic import BaseModel, TypeAdapter, ValidationError
 
+from workflowai.core._logger import logger
 from workflowai.core.domain.errors import BaseError, ErrorResponse, WorkflowAIError
 
 # A type for return values
 _R = TypeVar("_R")
 _M = TypeVar("_M", bound=BaseModel)
-
-_logger = logging.getLogger("WorkflowAI")
 
 
 class APIClient:
@@ -154,7 +152,7 @@ class APIClient:
                 in_data = False
 
         if data:
-            _logger.warning("Data left after processing", extra={"data": data})
+            logger.warning("Data left after processing", extra={"data": data})
 
     async def stream(
         self,

--- a/workflowai/core/client/_fn_utils.py
+++ b/workflowai/core/client/_fn_utils.py
@@ -23,7 +23,7 @@ from workflowai.core.client._types import (
     RunParams,
     RunTemplate,
 )
-from workflowai.core.client._utils import intolerant_validator
+from workflowai.core.client._utils import default_validator
 from workflowai.core.client.agent import Agent
 from workflowai.core.domain.errors import InvalidGenerationError
 from workflowai.core.domain.model import ModelOrStr
@@ -144,7 +144,7 @@ class _RunnableAgent(Agent[AgentInput, AgentOutput], Generic[AgentInput, AgentOu
         except InvalidGenerationError as e:
             if e.partial_output and e.run_id:
                 try:
-                    validator, _ = self._sanitize_validator(kwargs, intolerant_validator(self.output_cls))
+                    validator, _ = self._sanitize_validator(kwargs, default_validator(self.output_cls))
                     run = self._build_run_no_tools(
                         chunk=RunResponse(
                             id=e.run_id,
@@ -152,6 +152,7 @@ class _RunnableAgent(Agent[AgentInput, AgentOutput], Generic[AgentInput, AgentOu
                         ),
                         schema_id=self.schema_id or 0,
                         validator=validator,
+                        partial=False,
                     )
                     run.error = e.error
                     return run

--- a/workflowai/core/client/_models.py
+++ b/workflowai/core/client/_models.py
@@ -138,7 +138,7 @@ class RunResponse(BaseModel):
     ) -> Run[AgentOutput]:
         # We do partial validation if either:
         # - there are tool call requests, which means that the output can be empty
-        # - the run has not yet finished, for exmaple when streaming, in which case the duration_seconds is None
+        # - the run has not yet finished, for example when streaming, in which case the duration_seconds is None
         if partial is None:
             partial = bool(self.tool_call_requests) or self.duration_seconds is None
         return Run(

--- a/workflowai/core/client/_models_test.py
+++ b/workflowai/core/client/_models_test.py
@@ -45,8 +45,8 @@ class TestRunResponseToDomain:
         assert isinstance(parsed, Run)
         assert parsed.output.a == 1
         # b is not defined
-        with pytest.raises(AttributeError):
-            assert parsed.output.b
+
+        assert parsed.output.b == ""
 
     def test_no_version_optional(self):
         chunk = RunResponse.model_validate_json('{"id": "1", "task_output": {"a": 1}}')

--- a/workflowai/core/client/_models_test.py
+++ b/workflowai/core/client/_models_test.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ValidationError
 
 from tests.utils import fixture_text
 from workflowai.core.client._models import RunResponse
-from workflowai.core.client._utils import intolerant_validator, tolerant_validator
+from workflowai.core.client._utils import default_validator
 from workflowai.core.domain.run import Run
 from workflowai.core.domain.tool_call import ToolCallRequest
 
@@ -41,7 +41,7 @@ class TestRunResponseToDomain:
         with pytest.raises(ValidationError):  # sanity
             _TaskOutput.model_validate({"a": 1})
 
-        parsed = chunk.to_domain(task_id="1", task_schema_id=1, validator=tolerant_validator(_TaskOutput))
+        parsed = chunk.to_domain(task_id="1", task_schema_id=1, validator=default_validator(_TaskOutput))
         assert isinstance(parsed, Run)
         assert parsed.output.a == 1
         # b is not defined
@@ -52,18 +52,19 @@ class TestRunResponseToDomain:
         chunk = RunResponse.model_validate_json('{"id": "1", "task_output": {"a": 1}}')
         assert chunk
 
-        parsed = chunk.to_domain(task_id="1", task_schema_id=1, validator=tolerant_validator(_TaskOutputOpt))
+        parsed = chunk.to_domain(task_id="1", task_schema_id=1, validator=default_validator(_TaskOutputOpt))
         assert isinstance(parsed, Run)
         assert parsed.output.a == 1
         assert parsed.output.b is None
 
     def test_with_version(self):
+        """Full output is validated since the duration is passed and there are no tool calls"""
         chunk = RunResponse.model_validate_json(
             '{"id": "1", "task_output": {"a": 1, "b": "test"}, "cost_usd": 0.1, "duration_seconds": 1, "version": {"properties": {"a": 1, "b": "test"}}}',  # noqa: E501
         )
         assert chunk
 
-        parsed = chunk.to_domain(task_id="1", task_schema_id=1, validator=tolerant_validator(_TaskOutput))
+        parsed = chunk.to_domain(task_id="1", task_schema_id=1, validator=default_validator(_TaskOutput))
         assert isinstance(parsed, Run)
         assert parsed.output.a == 1
         assert parsed.output.b == "test"
@@ -73,17 +74,19 @@ class TestRunResponseToDomain:
 
     def test_with_version_validation_fails(self):
         chunk = RunResponse.model_validate_json(
-            '{"id": "1", "task_output": {"a": 1}, "version": {"properties": {"a": 1, "b": "test"}}}',
+            """{"id": "1", "task_output": {"a": 1},
+            "version": {"properties": {"a": 1, "b": "test"}}, "duration_seconds": 1}""",
         )
         with pytest.raises(ValidationError):
-            chunk.to_domain(task_id="1", task_schema_id=1, validator=intolerant_validator(_TaskOutput))
+            chunk.to_domain(task_id="1", task_schema_id=1, validator=default_validator(_TaskOutput))
 
     def test_with_tool_calls(self):
         chunk = RunResponse.model_validate_json(
-            '{"id": "1", "task_output": {}, "tool_call_requests": [{"id": "1", "name": "test", "input": {"a": 1}}]}',
+            """{"id": "1", "task_output": {},
+            "tool_call_requests": [{"id": "1", "name": "test", "input": {"a": 1}}], "duration_seconds": 1}""",
         )
         assert chunk
 
-        parsed = chunk.to_domain(task_id="1", task_schema_id=1, validator=tolerant_validator(_TaskOutput))
+        parsed = chunk.to_domain(task_id="1", task_schema_id=1, validator=default_validator(_TaskOutput))
         assert isinstance(parsed, Run)
         assert parsed.tool_call_requests == [ToolCallRequest(id="1", name="test", input={"a": 1})]

--- a/workflowai/core/client/_utils_test.py
+++ b/workflowai/core/client/_utils_test.py
@@ -2,8 +2,14 @@ from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
+from pydantic import BaseModel
 
-from workflowai.core.client._utils import build_retryable_wait, global_default_version_reference, split_chunks
+from workflowai.core.client._utils import (
+    build_retryable_wait,
+    global_default_version_reference,
+    split_chunks,
+    tolerant_validator,
+)
 from workflowai.core.domain.errors import BaseError, WorkflowAIError
 
 
@@ -42,3 +48,24 @@ class TestBuildRetryableWait:
 def test_global_default_version_reference(env_var: str, expected: Any):
     with patch.dict("os.environ", {"WORKFLOWAI_DEFAULT_VERSION": env_var}):
         assert global_default_version_reference() == expected
+
+
+# Create a nested object with only required properties
+class Recipe(BaseModel):
+    class Ingredient(BaseModel):
+        name: str
+        quantity: int
+
+    ingredients: list[Ingredient]
+
+
+class TestTolerantValidator:
+    def test_tolerant_validator_nested_object(self):
+        validated = tolerant_validator(Recipe)(
+            {
+                "ingredients": [{"name": "salt"}],
+            },
+            has_tool_call_requests=False,
+        )
+        for ingredient in validated.ingredients:
+            assert isinstance(ingredient, Recipe.Ingredient)

--- a/workflowai/core/client/_utils_test.py
+++ b/workflowai/core/client/_utils_test.py
@@ -6,9 +6,9 @@ from pydantic import BaseModel
 
 from workflowai.core.client._utils import (
     build_retryable_wait,
+    default_validator,
     global_default_version_reference,
     split_chunks,
-    tolerant_validator,
 )
 from workflowai.core.domain.errors import BaseError, WorkflowAIError
 
@@ -59,13 +59,13 @@ class Recipe(BaseModel):
     ingredients: list[Ingredient]
 
 
-class TestTolerantValidator:
+class TestValidator:
     def test_tolerant_validator_nested_object(self):
-        validated = tolerant_validator(Recipe)(
+        validated = default_validator(Recipe)(
             {
                 "ingredients": [{"name": "salt"}],
             },
-            has_tool_call_requests=False,
+            partial=True,
         )
         for ingredient in validated.ingredients:
             assert isinstance(ingredient, Recipe.Ingredient)

--- a/workflowai/core/client/agent.py
+++ b/workflowai/core/client/agent.py
@@ -444,7 +444,11 @@ class Agent(Generic[AgentInput, AgentOutput]):
                         )
                         final_error = None
                     except ValidationError as e:
-                        logger.debug("Validation error in stream", exc_info=e)
+                        logger.debug(
+                            "Client side validation error in stream. There is likely an "
+                            "issue with the validator or the model.",
+                            exc_info=e,
+                        )
                         final_error = e
                         continue
                 if final_error:

--- a/workflowai/core/client/agent_test.py
+++ b/workflowai/core/client/agent_test.py
@@ -171,9 +171,7 @@ class TestRun:
         assert messages == ["", "hel", "hello", "hello"]
 
         for chunk in chunks[:-1]:
-            with pytest.raises(AttributeError):
-                # Since the field is not optional, it will raise an attribute error
-                assert chunk.output.another_field
+            assert chunk.output.another_field == ""
         assert chunks[-1].output.another_field == "test"
 
         last_message = chunks[-1]

--- a/workflowai/core/client/agent_test.py
+++ b/workflowai/core/client/agent_test.py
@@ -447,558 +447,555 @@ class TestSanitizeVersion:
         }
 
 
-@pytest.mark.asyncio
-async def test_list_models(agent: Agent[HelloTaskInput, HelloTaskOutput], httpx_mock: HTTPXMock):
-    """Test that list_models correctly fetches and returns available models."""
-    # Mock the HTTP response instead of the API client method
-    httpx_mock.add_response(
-        url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
-        json={
-            "items": [
-                {
-                    "id": "gpt-4",
-                    "name": "GPT-4",
-                    "icon_url": "https://example.com/gpt4.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.01,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "OpenAI",
-                        "price_per_input_token_usd": 0.0001,
-                        "price_per_output_token_usd": 0.0002,
-                        "release_date": "2024-01-01",
-                        "context_window_tokens": 128000,
-                        "quality_index": 0.95,
+class TestListModels:
+    async def test_list_models(self, agent: Agent[HelloTaskInput, HelloTaskOutput], httpx_mock: HTTPXMock):
+        """Test that list_models correctly fetches and returns available models."""
+        # Mock the HTTP response instead of the API client method
+        httpx_mock.add_response(
+            url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
+            json={
+                "items": [
+                    {
+                        "id": "gpt-4",
+                        "name": "GPT-4",
+                        "icon_url": "https://example.com/gpt4.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.01,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "OpenAI",
+                            "price_per_input_token_usd": 0.0001,
+                            "price_per_output_token_usd": 0.0002,
+                            "release_date": "2024-01-01",
+                            "context_window_tokens": 128000,
+                            "quality_index": 0.95,
+                        },
+                        "is_default": True,
+                        "providers": ["openai"],
                     },
-                    "is_default": True,
-                    "providers": ["openai"],
-                },
-                {
-                    "id": "claude-3",
-                    "name": "Claude 3",
-                    "icon_url": "https://example.com/claude3.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.015,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "Anthropic",
-                        "price_per_input_token_usd": 0.00015,
-                        "price_per_output_token_usd": 0.00025,
-                        "release_date": "2024-03-01",
-                        "context_window_tokens": 200000,
-                        "quality_index": 0.98,
+                    {
+                        "id": "claude-3",
+                        "name": "Claude 3",
+                        "icon_url": "https://example.com/claude3.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.015,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "Anthropic",
+                            "price_per_input_token_usd": 0.00015,
+                            "price_per_output_token_usd": 0.00025,
+                            "release_date": "2024-03-01",
+                            "context_window_tokens": 200000,
+                            "quality_index": 0.98,
+                        },
+                        "is_default": False,
+                        "providers": ["anthropic"],
                     },
-                    "is_default": False,
-                    "providers": ["anthropic"],
-                },
-            ],
-            "count": 2,
-        },
-    )
+                ],
+                "count": 2,
+            },
+        )
 
-    # Call the method
-    models = await agent.list_models()
+        # Call the method
+        models = await agent.list_models()
 
-    # Verify the HTTP request was made correctly
-    request = httpx_mock.get_request()
-    assert request is not None, "Expected an HTTP request to be made"
-    assert request.method == "POST"
-    assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
-    assert json.loads(request.content) == {}
+        # Verify the HTTP request was made correctly
+        request = httpx_mock.get_request()
+        assert request is not None, "Expected an HTTP request to be made"
+        assert request.method == "POST"
+        assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
+        assert json.loads(request.content) == {}
 
-    # Verify we get back the full ModelInfo objects
-    assert len(models) == 2
-    assert isinstance(models[0], ModelInfo)
-    assert models[0].id == "gpt-4"
-    assert models[0].name == "GPT-4"
-    assert models[0].modes == ["chat"]
-    assert models[0].metadata is not None
-    assert models[0].metadata.provider_name == "OpenAI"
+        # Verify we get back the full ModelInfo objects
+        assert len(models) == 2
+        assert isinstance(models[0], ModelInfo)
+        assert models[0].id == "gpt-4"
+        assert models[0].name == "GPT-4"
+        assert models[0].modes == ["chat"]
+        assert models[0].metadata is not None
+        assert models[0].metadata.provider_name == "OpenAI"
 
-    assert isinstance(models[1], ModelInfo)
-    assert models[1].id == "claude-3"
-    assert models[1].name == "Claude 3"
-    assert models[1].modes == ["chat"]
-    assert models[1].metadata is not None
-    assert models[1].metadata.provider_name == "Anthropic"
+        assert isinstance(models[1], ModelInfo)
+        assert models[1].id == "claude-3"
+        assert models[1].name == "Claude 3"
+        assert models[1].modes == ["chat"]
+        assert models[1].metadata is not None
+        assert models[1].metadata.provider_name == "Anthropic"
 
-
-@pytest.mark.asyncio
-async def test_list_models_with_params_override(agent: Agent[HelloTaskInput, HelloTaskOutput], httpx_mock: HTTPXMock):
-    """Test that list_models correctly fetches and returns available models."""
-    # Mock the HTTP response instead of the API client method
-    httpx_mock.add_response(
-        url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
-        json={
-            "items": [
-                {
-                    "id": "gpt-4",
-                    "name": "GPT-4",
-                    "icon_url": "https://example.com/gpt4.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.01,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "OpenAI",
-                        "price_per_input_token_usd": 0.0001,
-                        "price_per_output_token_usd": 0.0002,
-                        "release_date": "2024-01-01",
-                        "context_window_tokens": 128000,
-                        "quality_index": 0.95,
+    async def test_list_models_with_params_override(
+        self,
+        agent: Agent[HelloTaskInput, HelloTaskOutput],
+        httpx_mock: HTTPXMock,
+    ):
+        """Test that list_models correctly fetches and returns available models."""
+        # Mock the HTTP response instead of the API client method
+        httpx_mock.add_response(
+            url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
+            json={
+                "items": [
+                    {
+                        "id": "gpt-4",
+                        "name": "GPT-4",
+                        "icon_url": "https://example.com/gpt4.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.01,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "OpenAI",
+                            "price_per_input_token_usd": 0.0001,
+                            "price_per_output_token_usd": 0.0002,
+                            "release_date": "2024-01-01",
+                            "context_window_tokens": 128000,
+                            "quality_index": 0.95,
+                        },
+                        "is_default": True,
+                        "providers": ["openai"],
                     },
-                    "is_default": True,
-                    "providers": ["openai"],
-                },
-                {
-                    "id": "claude-3",
-                    "name": "Claude 3",
-                    "icon_url": "https://example.com/claude3.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.015,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "Anthropic",
-                        "price_per_input_token_usd": 0.00015,
-                        "price_per_output_token_usd": 0.00025,
-                        "release_date": "2024-03-01",
-                        "context_window_tokens": 200000,
-                        "quality_index": 0.98,
+                    {
+                        "id": "claude-3",
+                        "name": "Claude 3",
+                        "icon_url": "https://example.com/claude3.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.015,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "Anthropic",
+                            "price_per_input_token_usd": 0.00015,
+                            "price_per_output_token_usd": 0.00025,
+                            "release_date": "2024-03-01",
+                            "context_window_tokens": 200000,
+                            "quality_index": 0.98,
+                        },
+                        "is_default": False,
+                        "providers": ["anthropic"],
                     },
-                    "is_default": False,
-                    "providers": ["anthropic"],
-                },
-            ],
-            "count": 2,
-        },
-    )
+                ],
+                "count": 2,
+            },
+        )
 
-    # Call the method
-    models = await agent.list_models(instructions="Some override instructions", requires_tools=True)
+        # Call the method
+        models = await agent.list_models(instructions="Some override instructions", requires_tools=True)
 
-    # Verify the HTTP request was made correctly
-    request = httpx_mock.get_request()
-    assert request is not None, "Expected an HTTP request to be made"
-    assert request.method == "POST"
-    assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
-    assert json.loads(request.content) == {
-        "instructions": "Some override instructions",
-        "requires_tools": True,
-    }
+        # Verify the HTTP request was made correctly
+        request = httpx_mock.get_request()
+        assert request is not None, "Expected an HTTP request to be made"
+        assert request.method == "POST"
+        assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
+        assert json.loads(request.content) == {
+            "instructions": "Some override instructions",
+            "requires_tools": True,
+        }
 
-    # Verify we get back the full ModelInfo objects
-    assert len(models) == 2
-    assert isinstance(models[0], ModelInfo)
-    assert models[0].id == "gpt-4"
-    assert models[0].name == "GPT-4"
-    assert models[0].modes == ["chat"]
-    assert models[0].metadata is not None
-    assert models[0].metadata.provider_name == "OpenAI"
+        # Verify we get back the full ModelInfo objects
+        assert len(models) == 2
+        assert isinstance(models[0], ModelInfo)
+        assert models[0].id == "gpt-4"
+        assert models[0].name == "GPT-4"
+        assert models[0].modes == ["chat"]
+        assert models[0].metadata is not None
+        assert models[0].metadata.provider_name == "OpenAI"
 
-    assert isinstance(models[1], ModelInfo)
-    assert models[1].id == "claude-3"
-    assert models[1].name == "Claude 3"
-    assert models[1].modes == ["chat"]
-    assert models[1].metadata is not None
-    assert models[1].metadata.provider_name == "Anthropic"
+        assert isinstance(models[1], ModelInfo)
+        assert models[1].id == "claude-3"
+        assert models[1].name == "Claude 3"
+        assert models[1].modes == ["chat"]
+        assert models[1].metadata is not None
+        assert models[1].metadata.provider_name == "Anthropic"
 
-
-@pytest.mark.asyncio
-async def test_list_models_with_params_override_and_agent_with_tools_and_instructions(
-    agent_with_tools_and_instructions: Agent[HelloTaskInput, HelloTaskOutput],
-    httpx_mock: HTTPXMock,
-):
-    """Test that list_models correctly fetches and returns available models."""
-    # Mock the HTTP response instead of the API client method
-    httpx_mock.add_response(
-        url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
-        json={
-            "items": [
-                {
-                    "id": "gpt-4",
-                    "name": "GPT-4",
-                    "icon_url": "https://example.com/gpt4.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.01,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "OpenAI",
-                        "price_per_input_token_usd": 0.0001,
-                        "price_per_output_token_usd": 0.0002,
-                        "release_date": "2024-01-01",
-                        "context_window_tokens": 128000,
-                        "quality_index": 0.95,
+    async def test_list_models_with_params_override_and_agent_with_tools_and_instructions(
+        self,
+        agent_with_tools_and_instructions: Agent[HelloTaskInput, HelloTaskOutput],
+        httpx_mock: HTTPXMock,
+    ):
+        """Test that list_models correctly fetches and returns available models."""
+        # Mock the HTTP response instead of the API client method
+        httpx_mock.add_response(
+            url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
+            json={
+                "items": [
+                    {
+                        "id": "gpt-4",
+                        "name": "GPT-4",
+                        "icon_url": "https://example.com/gpt4.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.01,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "OpenAI",
+                            "price_per_input_token_usd": 0.0001,
+                            "price_per_output_token_usd": 0.0002,
+                            "release_date": "2024-01-01",
+                            "context_window_tokens": 128000,
+                            "quality_index": 0.95,
+                        },
+                        "is_default": True,
+                        "providers": ["openai"],
                     },
-                    "is_default": True,
-                    "providers": ["openai"],
-                },
-                {
-                    "id": "claude-3",
-                    "name": "Claude 3",
-                    "icon_url": "https://example.com/claude3.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.015,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "Anthropic",
-                        "price_per_input_token_usd": 0.00015,
-                        "price_per_output_token_usd": 0.00025,
-                        "release_date": "2024-03-01",
-                        "context_window_tokens": 200000,
-                        "quality_index": 0.98,
+                    {
+                        "id": "claude-3",
+                        "name": "Claude 3",
+                        "icon_url": "https://example.com/claude3.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.015,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "Anthropic",
+                            "price_per_input_token_usd": 0.00015,
+                            "price_per_output_token_usd": 0.00025,
+                            "release_date": "2024-03-01",
+                            "context_window_tokens": 200000,
+                            "quality_index": 0.98,
+                        },
+                        "is_default": False,
+                        "providers": ["anthropic"],
                     },
-                    "is_default": False,
-                    "providers": ["anthropic"],
-                },
-            ],
-            "count": 2,
-        },
-    )
+                ],
+                "count": 2,
+            },
+        )
 
-    # Call the method
-    models = await agent_with_tools_and_instructions.list_models(
-        instructions="Some override instructions",
-        requires_tools=False,
-    )
+        # Call the method
+        models = await agent_with_tools_and_instructions.list_models(
+            instructions="Some override instructions",
+            requires_tools=False,
+        )
 
-    # Verify the HTTP request was made correctly
-    request = httpx_mock.get_request()
-    assert request is not None, "Expected an HTTP request to be made"
-    assert request.method == "POST"
-    assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
-    assert json.loads(request.content) == {
-        "instructions": "Some override instructions",
-        "requires_tools": False,
-    }
+        # Verify the HTTP request was made correctly
+        request = httpx_mock.get_request()
+        assert request is not None, "Expected an HTTP request to be made"
+        assert request.method == "POST"
+        assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
+        assert json.loads(request.content) == {
+            "instructions": "Some override instructions",
+            "requires_tools": False,
+        }
 
-    # Verify we get back the full ModelInfo objects
-    assert len(models) == 2
-    assert isinstance(models[0], ModelInfo)
-    assert models[0].id == "gpt-4"
-    assert models[0].name == "GPT-4"
-    assert models[0].modes == ["chat"]
-    assert models[0].metadata is not None
-    assert models[0].metadata.provider_name == "OpenAI"
+        # Verify we get back the full ModelInfo objects
+        assert len(models) == 2
+        assert isinstance(models[0], ModelInfo)
+        assert models[0].id == "gpt-4"
+        assert models[0].name == "GPT-4"
+        assert models[0].modes == ["chat"]
+        assert models[0].metadata is not None
+        assert models[0].metadata.provider_name == "OpenAI"
 
-    assert isinstance(models[1], ModelInfo)
-    assert models[1].id == "claude-3"
-    assert models[1].name == "Claude 3"
-    assert models[1].modes == ["chat"]
-    assert models[1].metadata is not None
-    assert models[1].metadata.provider_name == "Anthropic"
+        assert isinstance(models[1], ModelInfo)
+        assert models[1].id == "claude-3"
+        assert models[1].name == "Claude 3"
+        assert models[1].modes == ["chat"]
+        assert models[1].metadata is not None
+        assert models[1].metadata.provider_name == "Anthropic"
 
+    async def test_list_models_registers_if_needed(
+        self,
+        agent_no_schema: Agent[HelloTaskInput, HelloTaskOutput],
+        httpx_mock: HTTPXMock,
+    ):
+        """Test that list_models registers the agent if it hasn't been registered yet."""
+        # Mock the registration response
+        httpx_mock.add_response(
+            url="http://localhost:8000/v1/_/agents",
+            json={"id": "123", "schema_id": 2},
+        )
 
-@pytest.mark.asyncio
-async def test_list_models_registers_if_needed(
-    agent_no_schema: Agent[HelloTaskInput, HelloTaskOutput],
-    httpx_mock: HTTPXMock,
-):
-    """Test that list_models registers the agent if it hasn't been registered yet."""
-    # Mock the registration response
-    httpx_mock.add_response(
-        url="http://localhost:8000/v1/_/agents",
-        json={"id": "123", "schema_id": 2},
-    )
-
-    # Mock the models response with the new structure
-    httpx_mock.add_response(
-        url="http://localhost:8000/v1/_/agents/123/schemas/2/models",
-        json={
-            "items": [
-                {
-                    "id": "gpt-4",
-                    "name": "GPT-4",
-                    "icon_url": "https://example.com/gpt4.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.01,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "OpenAI",
-                        "price_per_input_token_usd": 0.0001,
-                        "price_per_output_token_usd": 0.0002,
-                        "release_date": "2024-01-01",
-                        "context_window_tokens": 128000,
-                        "quality_index": 0.95,
+        # Mock the models response with the new structure
+        httpx_mock.add_response(
+            url="http://localhost:8000/v1/_/agents/123/schemas/2/models",
+            json={
+                "items": [
+                    {
+                        "id": "gpt-4",
+                        "name": "GPT-4",
+                        "icon_url": "https://example.com/gpt4.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.01,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "OpenAI",
+                            "price_per_input_token_usd": 0.0001,
+                            "price_per_output_token_usd": 0.0002,
+                            "release_date": "2024-01-01",
+                            "context_window_tokens": 128000,
+                            "quality_index": 0.95,
+                        },
+                        "is_default": True,
+                        "providers": ["openai"],
                     },
-                    "is_default": True,
-                    "providers": ["openai"],
-                },
-            ],
-            "count": 1,
-        },
-    )
+                ],
+                "count": 1,
+            },
+        )
 
-    # Call the method
-    models = await agent_no_schema.list_models()
+        # Call the method
+        models = await agent_no_schema.list_models()
 
-    # Verify both API calls were made
-    reqs = httpx_mock.get_requests()
-    assert len(reqs) == 2
-    assert reqs[0].url == "http://localhost:8000/v1/_/agents"
-    assert reqs[1].method == "POST"
-    assert reqs[1].url == "http://localhost:8000/v1/_/agents/123/schemas/2/models"
-    assert json.loads(reqs[1].content) == {}
+        # Verify both API calls were made
+        reqs = httpx_mock.get_requests()
+        assert len(reqs) == 2
+        assert reqs[0].url == "http://localhost:8000/v1/_/agents"
+        assert reqs[1].method == "POST"
+        assert reqs[1].url == "http://localhost:8000/v1/_/agents/123/schemas/2/models"
+        assert json.loads(reqs[1].content) == {}
 
-    # Verify we get back the full ModelInfo object
-    assert len(models) == 1
-    assert isinstance(models[0], ModelInfo)
-    assert models[0].id == "gpt-4"
-    assert models[0].name == "GPT-4"
-    assert models[0].modes == ["chat"]
-    assert models[0].metadata is not None
-    assert models[0].metadata.provider_name == "OpenAI"
+        # Verify we get back the full ModelInfo object
+        assert len(models) == 1
+        assert isinstance(models[0], ModelInfo)
+        assert models[0].id == "gpt-4"
+        assert models[0].name == "GPT-4"
+        assert models[0].modes == ["chat"]
+        assert models[0].metadata is not None
+        assert models[0].metadata.provider_name == "OpenAI"
 
-
-@pytest.mark.asyncio
-async def test_list_models_with_instructions(
-    agent_with_instructions: Agent[HelloTaskInput, HelloTaskOutput],
-    httpx_mock: HTTPXMock,
-):
-    """Test that list_models correctly fetches and returns available models."""
-    # Mock the HTTP response instead of the API client method
-    httpx_mock.add_response(
-        method="POST",
-        url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
-        json={
-            "items": [
-                {
-                    "id": "gpt-4",
-                    "name": "GPT-4",
-                    "icon_url": "https://example.com/gpt4.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.01,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "OpenAI",
-                        "price_per_input_token_usd": 0.0001,
-                        "price_per_output_token_usd": 0.0002,
-                        "release_date": "2024-01-01",
-                        "context_window_tokens": 128000,
-                        "quality_index": 0.95,
+    async def test_list_models_with_instructions(
+        self,
+        agent_with_instructions: Agent[HelloTaskInput, HelloTaskOutput],
+        httpx_mock: HTTPXMock,
+    ):
+        """Test that list_models correctly fetches and returns available models."""
+        # Mock the HTTP response instead of the API client method
+        httpx_mock.add_response(
+            method="POST",
+            url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
+            json={
+                "items": [
+                    {
+                        "id": "gpt-4",
+                        "name": "GPT-4",
+                        "icon_url": "https://example.com/gpt4.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.01,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "OpenAI",
+                            "price_per_input_token_usd": 0.0001,
+                            "price_per_output_token_usd": 0.0002,
+                            "release_date": "2024-01-01",
+                            "context_window_tokens": 128000,
+                            "quality_index": 0.95,
+                        },
+                        "is_default": True,
+                        "providers": ["openai"],
                     },
-                    "is_default": True,
-                    "providers": ["openai"],
-                },
-                {
-                    "id": "claude-3",
-                    "name": "Claude 3",
-                    "icon_url": "https://example.com/claude3.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.015,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "Anthropic",
-                        "price_per_input_token_usd": 0.00015,
-                        "price_per_output_token_usd": 0.00025,
-                        "release_date": "2024-03-01",
-                        "context_window_tokens": 200000,
-                        "quality_index": 0.98,
+                    {
+                        "id": "claude-3",
+                        "name": "Claude 3",
+                        "icon_url": "https://example.com/claude3.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.015,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "Anthropic",
+                            "price_per_input_token_usd": 0.00015,
+                            "price_per_output_token_usd": 0.00025,
+                            "release_date": "2024-03-01",
+                            "context_window_tokens": 200000,
+                            "quality_index": 0.98,
+                        },
+                        "is_default": False,
+                        "providers": ["anthropic"],
                     },
-                    "is_default": False,
-                    "providers": ["anthropic"],
-                },
-            ],
-            "count": 2,
-        },
-    )
+                ],
+                "count": 2,
+            },
+        )
 
-    # Call the method
-    models = await agent_with_instructions.list_models()
+        # Call the method
+        models = await agent_with_instructions.list_models()
 
-    # Verify the HTTP request was made correctly
-    request = httpx_mock.get_request()
-    assert request is not None, "Expected an HTTP request to be made"
-    assert request.method == "POST"
-    assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
-    assert json.loads(request.content) == {"instructions": "Some instructions"}
+        # Verify the HTTP request was made correctly
+        request = httpx_mock.get_request()
+        assert request is not None, "Expected an HTTP request to be made"
+        assert request.method == "POST"
+        assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
+        assert json.loads(request.content) == {"instructions": "Some instructions"}
 
-    # Verify we get back the full ModelInfo objects
-    assert len(models) == 2
-    assert isinstance(models[0], ModelInfo)
-    assert models[0].id == "gpt-4"
-    assert models[0].name == "GPT-4"
-    assert models[0].modes == ["chat"]
-    assert models[0].metadata is not None
-    assert models[0].metadata.provider_name == "OpenAI"
+        # Verify we get back the full ModelInfo objects
+        assert len(models) == 2
+        assert isinstance(models[0], ModelInfo)
+        assert models[0].id == "gpt-4"
+        assert models[0].name == "GPT-4"
+        assert models[0].modes == ["chat"]
+        assert models[0].metadata is not None
+        assert models[0].metadata.provider_name == "OpenAI"
 
-    assert isinstance(models[1], ModelInfo)
-    assert models[1].id == "claude-3"
-    assert models[1].name == "Claude 3"
-    assert models[1].modes == ["chat"]
-    assert models[1].metadata is not None
-    assert models[1].metadata.provider_name == "Anthropic"
+        assert isinstance(models[1], ModelInfo)
+        assert models[1].id == "claude-3"
+        assert models[1].name == "Claude 3"
+        assert models[1].modes == ["chat"]
+        assert models[1].metadata is not None
+        assert models[1].metadata.provider_name == "Anthropic"
 
-
-@pytest.mark.asyncio
-async def test_list_models_with_tools(
-    agent_with_tools: Agent[HelloTaskInput, HelloTaskOutput],
-    httpx_mock: HTTPXMock,
-):
-    """Test that list_models correctly fetches and returns available models."""
-    # Mock the HTTP response instead of the API client method
-    httpx_mock.add_response(
-        method="POST",
-        url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
-        json={
-            "items": [
-                {
-                    "id": "gpt-4",
-                    "name": "GPT-4",
-                    "icon_url": "https://example.com/gpt4.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.01,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "OpenAI",
-                        "price_per_input_token_usd": 0.0001,
-                        "price_per_output_token_usd": 0.0002,
-                        "release_date": "2024-01-01",
-                        "context_window_tokens": 128000,
-                        "quality_index": 0.95,
+    async def test_list_models_with_tools(
+        self,
+        agent_with_tools: Agent[HelloTaskInput, HelloTaskOutput],
+        httpx_mock: HTTPXMock,
+    ):
+        """Test that list_models correctly fetches and returns available models."""
+        # Mock the HTTP response instead of the API client method
+        httpx_mock.add_response(
+            method="POST",
+            url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
+            json={
+                "items": [
+                    {
+                        "id": "gpt-4",
+                        "name": "GPT-4",
+                        "icon_url": "https://example.com/gpt4.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.01,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "OpenAI",
+                            "price_per_input_token_usd": 0.0001,
+                            "price_per_output_token_usd": 0.0002,
+                            "release_date": "2024-01-01",
+                            "context_window_tokens": 128000,
+                            "quality_index": 0.95,
+                        },
+                        "is_default": True,
+                        "providers": ["openai"],
                     },
-                    "is_default": True,
-                    "providers": ["openai"],
-                },
-                {
-                    "id": "claude-3",
-                    "name": "Claude 3",
-                    "icon_url": "https://example.com/claude3.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.015,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "Anthropic",
-                        "price_per_input_token_usd": 0.00015,
-                        "price_per_output_token_usd": 0.00025,
-                        "release_date": "2024-03-01",
-                        "context_window_tokens": 200000,
-                        "quality_index": 0.98,
+                    {
+                        "id": "claude-3",
+                        "name": "Claude 3",
+                        "icon_url": "https://example.com/claude3.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.015,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "Anthropic",
+                            "price_per_input_token_usd": 0.00015,
+                            "price_per_output_token_usd": 0.00025,
+                            "release_date": "2024-03-01",
+                            "context_window_tokens": 200000,
+                            "quality_index": 0.98,
+                        },
+                        "is_default": False,
+                        "providers": ["anthropic"],
                     },
-                    "is_default": False,
-                    "providers": ["anthropic"],
-                },
-            ],
-            "count": 2,
-        },
-    )
+                ],
+                "count": 2,
+            },
+        )
 
-    # Call the method
-    models = await agent_with_tools.list_models()
+        # Call the method
+        models = await agent_with_tools.list_models()
 
-    # Verify the HTTP request was made correctly
-    request = httpx_mock.get_request()
-    assert request is not None, "Expected an HTTP request to be made"
-    assert request.method == "POST"
-    assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
-    assert json.loads(request.content) == {"requires_tools": True}
+        # Verify the HTTP request was made correctly
+        request = httpx_mock.get_request()
+        assert request is not None, "Expected an HTTP request to be made"
+        assert request.method == "POST"
+        assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
+        assert json.loads(request.content) == {"requires_tools": True}
 
-    # Verify we get back the full ModelInfo objects
-    assert len(models) == 2
-    assert isinstance(models[0], ModelInfo)
-    assert models[0].id == "gpt-4"
-    assert models[0].name == "GPT-4"
-    assert models[0].modes == ["chat"]
-    assert models[0].metadata is not None
-    assert models[0].metadata.provider_name == "OpenAI"
+        # Verify we get back the full ModelInfo objects
+        assert len(models) == 2
+        assert isinstance(models[0], ModelInfo)
+        assert models[0].id == "gpt-4"
+        assert models[0].name == "GPT-4"
+        assert models[0].modes == ["chat"]
+        assert models[0].metadata is not None
+        assert models[0].metadata.provider_name == "OpenAI"
 
-    assert isinstance(models[1], ModelInfo)
-    assert models[1].id == "claude-3"
-    assert models[1].name == "Claude 3"
-    assert models[1].modes == ["chat"]
-    assert models[1].metadata is not None
-    assert models[1].metadata.provider_name == "Anthropic"
+        assert isinstance(models[1], ModelInfo)
+        assert models[1].id == "claude-3"
+        assert models[1].name == "Claude 3"
+        assert models[1].modes == ["chat"]
+        assert models[1].metadata is not None
+        assert models[1].metadata.provider_name == "Anthropic"
 
-
-@pytest.mark.asyncio
-async def test_list_models_with_instructions_and_tools(
-    agent_with_tools_and_instructions: Agent[HelloTaskInput, HelloTaskOutput],
-    httpx_mock: HTTPXMock,
-):
-    """Test that list_models correctly fetches and returns available models."""
-    # Mock the HTTP response instead of the API client method
-    httpx_mock.add_response(
-        method="POST",
-        url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
-        json={
-            "items": [
-                {
-                    "id": "gpt-4",
-                    "name": "GPT-4",
-                    "icon_url": "https://example.com/gpt4.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.01,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "OpenAI",
-                        "price_per_input_token_usd": 0.0001,
-                        "price_per_output_token_usd": 0.0002,
-                        "release_date": "2024-01-01",
-                        "context_window_tokens": 128000,
-                        "quality_index": 0.95,
+    async def test_list_models_with_instructions_and_tools(
+        self,
+        agent_with_tools_and_instructions: Agent[HelloTaskInput, HelloTaskOutput],
+        httpx_mock: HTTPXMock,
+    ):
+        """Test that list_models correctly fetches and returns available models."""
+        # Mock the HTTP response instead of the API client method
+        httpx_mock.add_response(
+            method="POST",
+            url="http://localhost:8000/v1/_/agents/123/schemas/1/models",
+            json={
+                "items": [
+                    {
+                        "id": "gpt-4",
+                        "name": "GPT-4",
+                        "icon_url": "https://example.com/gpt4.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.01,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "OpenAI",
+                            "price_per_input_token_usd": 0.0001,
+                            "price_per_output_token_usd": 0.0002,
+                            "release_date": "2024-01-01",
+                            "context_window_tokens": 128000,
+                            "quality_index": 0.95,
+                        },
+                        "is_default": True,
+                        "providers": ["openai"],
                     },
-                    "is_default": True,
-                    "providers": ["openai"],
-                },
-                {
-                    "id": "claude-3",
-                    "name": "Claude 3",
-                    "icon_url": "https://example.com/claude3.png",
-                    "modes": ["chat"],
-                    "is_not_supported_reason": None,
-                    "average_cost_per_run_usd": 0.015,
-                    "is_latest": True,
-                    "metadata": {
-                        "provider_name": "Anthropic",
-                        "price_per_input_token_usd": 0.00015,
-                        "price_per_output_token_usd": 0.00025,
-                        "release_date": "2024-03-01",
-                        "context_window_tokens": 200000,
-                        "quality_index": 0.98,
+                    {
+                        "id": "claude-3",
+                        "name": "Claude 3",
+                        "icon_url": "https://example.com/claude3.png",
+                        "modes": ["chat"],
+                        "is_not_supported_reason": None,
+                        "average_cost_per_run_usd": 0.015,
+                        "is_latest": True,
+                        "metadata": {
+                            "provider_name": "Anthropic",
+                            "price_per_input_token_usd": 0.00015,
+                            "price_per_output_token_usd": 0.00025,
+                            "release_date": "2024-03-01",
+                            "context_window_tokens": 200000,
+                            "quality_index": 0.98,
+                        },
+                        "is_default": False,
+                        "providers": ["anthropic"],
                     },
-                    "is_default": False,
-                    "providers": ["anthropic"],
-                },
-            ],
-            "count": 2,
-        },
-    )
+                ],
+                "count": 2,
+            },
+        )
 
-    # Call the method
-    models = await agent_with_tools_and_instructions.list_models()
+        # Call the method
+        models = await agent_with_tools_and_instructions.list_models()
 
-    # Verify the HTTP request was made correctly
-    request = httpx_mock.get_request()
-    assert request is not None, "Expected an HTTP request to be made"
-    assert request.method == "POST"
-    assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
-    assert json.loads(request.content) == {"instructions": "Some instructions", "requires_tools": True}
+        # Verify the HTTP request was made correctly
+        request = httpx_mock.get_request()
+        assert request is not None, "Expected an HTTP request to be made"
+        assert request.method == "POST"
+        assert request.url == "http://localhost:8000/v1/_/agents/123/schemas/1/models"
+        assert json.loads(request.content) == {"instructions": "Some instructions", "requires_tools": True}
 
-    # Verify we get back the full ModelInfo objects
-    assert len(models) == 2
-    assert isinstance(models[0], ModelInfo)
-    assert models[0].id == "gpt-4"
-    assert models[0].name == "GPT-4"
-    assert models[0].modes == ["chat"]
-    assert models[0].metadata is not None
-    assert models[0].metadata.provider_name == "OpenAI"
+        # Verify we get back the full ModelInfo objects
+        assert len(models) == 2
+        assert isinstance(models[0], ModelInfo)
+        assert models[0].id == "gpt-4"
+        assert models[0].name == "GPT-4"
+        assert models[0].modes == ["chat"]
+        assert models[0].metadata is not None
+        assert models[0].metadata.provider_name == "OpenAI"
 
-    assert isinstance(models[1], ModelInfo)
-    assert models[1].id == "claude-3"
-    assert models[1].name == "Claude 3"
-    assert models[1].modes == ["chat"]
-    assert models[1].metadata is not None
-    assert models[1].metadata.provider_name == "Anthropic"
+        assert isinstance(models[1], ModelInfo)
+        assert models[1].id == "claude-3"
+        assert models[1].name == "Claude 3"
+        assert models[1].modes == ["chat"]
+        assert models[1].metadata is not None
+        assert models[1].metadata.provider_name == "Anthropic"
 
 
 class TestFetchCompletions:

--- a/workflowai/core/domain/model.py
+++ b/workflowai/core/domain/model.py
@@ -34,6 +34,7 @@ class Model(str, Enum):
     O1_PREVIEW_2024_09_12 = "o1-preview-2024-09-12"
     O1_MINI_LATEST = "o1-mini-latest"
     O1_MINI_2024_09_12 = "o1-mini-2024-09-12"
+    GPT_45_PREVIEW_2025_02_27 = "gpt-4.5-preview-2025-02-27"
     GPT_4O_AUDIO_PREVIEW_2024_12_17 = "gpt-4o-audio-preview-2024-12-17"
     GPT_40_AUDIO_PREVIEW_2024_10_01 = "gpt-4o-audio-preview-2024-10-01"
     GPT_4_TURBO_2024_04_09 = "gpt-4-turbo-2024-04-09"

--- a/workflowai/core/domain/model_test.py
+++ b/workflowai/core/domain/model_test.py
@@ -1,0 +1,15 @@
+import httpx
+
+from workflowai.core.domain.model import Model
+
+
+async def test_model_exhaustive():
+    """Make sure the list of models is synchronized with the prod API"""
+    async with httpx.AsyncClient() as client:
+        response = await client.get("https://run.workflowai.com/v1/models")
+        response.raise_for_status()
+        models: list[str] = response.json()
+
+    # Converting to a set of strings should not be needed
+    # but it makes pytest errors prettier
+    assert set(models) == {m.value for m in Model}

--- a/workflowai/core/utils/_pydantic.py
+++ b/workflowai/core/utils/_pydantic.py
@@ -1,0 +1,79 @@
+from collections.abc import Collection, Mapping
+from typing import Any, Optional, get_args, get_origin
+
+from pydantic import BaseModel
+
+from workflowai.core.utils._vars import BM
+
+
+def _safe_issubclass(cls: type[Any], other: type[Any]) -> bool:
+    try:
+        return issubclass(cls, other)
+    except TypeError:
+        return False
+
+
+def _construct_list(annotation: type[Any], payload: list[Any]) -> Collection[Any]:
+    origin = get_origin(annotation)
+    # If the type annotation is not a collection, the we can't handle it so we return as is
+    if not origin or not _safe_issubclass(origin, Collection):
+        return payload
+
+    args = get_args(annotation)
+    if not args:
+        return payload
+
+    constructor = set if _safe_issubclass(origin, set) else list
+
+    if len(args) == 1 and _safe_issubclass(args[0], BaseModel):
+        return constructor([construct_model_recursive(args[0], item) for item in payload])  # pyright: ignore [reportUnknownVariableType, reportCallIssue]
+
+    return payload
+
+
+def _construct_object(annotation: type[Any], payload: dict[str, Any]) -> Any:
+    if _safe_issubclass(annotation, BaseModel):
+        return construct_model_recursive(annotation, payload)  # pyright: ignore [reportUnknownVariableType, reportArgumentType]
+
+    # Try to map dict of objects
+    origin = get_origin(annotation)
+    if not origin or not _safe_issubclass(origin, Mapping):
+        return payload
+
+    args = get_args(annotation)
+    if len(args) != 2:
+        return payload
+
+    key_type, value_type = args
+    if key_type is not str:
+        return payload
+    return {k: _construct_for_annotation(value_type, v) for k, v in payload.items()}
+
+
+def _construct_for_annotation(annotation: Optional[type[Any]], payload: Any) -> Any:
+    if annotation is None:
+        return payload
+
+    if isinstance(payload, dict):
+        return _construct_object(annotation, payload)  # pyright: ignore [reportUnknownArgumentType]
+    if isinstance(payload, list):
+        return _construct_list(annotation, payload)  # pyright: ignore [reportUnknownArgumentType]
+
+    return payload
+
+
+# It does not look like there is an easy way to construct models from partial json objects
+# - https://github.com/team23/pydantic-partial uses a heavy approach by constructing a new dynamic
+# model class with non required fields
+# - partial validation https://docs.pydantic.dev/latest/concepts/experimental/#partial-validation
+# handles partial jsons but still validates that each field is present so it fails in our case
+# where we just want to handle missing fields
+def construct_model_recursive(model: type[BM], payload: dict[str, Any]) -> BM:
+    """
+    Recursively calls model construct to build a model from partial json object
+    """
+    mapped: dict[str, Any] = {}
+    for k, v in payload.items():
+        field = model.model_fields[k]
+        mapped[k] = _construct_for_annotation(field.annotation, v)
+    return model.model_construct(None, **mapped)

--- a/workflowai/core/utils/_pydantic.py
+++ b/workflowai/core/utils/_pydantic.py
@@ -1,79 +1,104 @@
-from collections.abc import Collection, Mapping
-from typing import Any, Optional, get_args, get_origin
+from collections.abc import Mapping, Sequence
+from typing import Any, TypeVar, get_args, get_origin
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, create_model
+from pydantic.fields import FieldInfo
+from pydantic_core import PydanticUndefined
+from typing_extensions import TypeGuard
 
+from workflowai.core._logger import logger
 from workflowai.core.utils._vars import BM
 
+_T = TypeVar("_T")
 
-def _safe_issubclass(cls: type[Any], other: type[Any]) -> bool:
+
+def _safe_issubclass(val: type[_T], cls: type[_T]) -> TypeGuard[type[_T]]:
     try:
-        return issubclass(cls, other)
+        return issubclass(val, cls)
     except TypeError:
         return False
 
 
-def _construct_list(annotation: type[Any], payload: list[Any]) -> Collection[Any]:
-    origin = get_origin(annotation)
-    # If the type annotation is not a collection, the we can't handle it so we return as is
-    if not origin or not _safe_issubclass(origin, Collection):
-        return payload
+def _copy_field_info(field_info: FieldInfo, **overrides: Any):
+    """
+    Return a copy of a pydantic FieldInfo object, allow to override
+    certain values.
+    """
 
-    args = get_args(annotation)
-    if not args:
-        return payload
+    kwargs = overrides
+    for k, v in field_info.__repr_args__():
+        if k in kwargs or not k:
+            continue
+        kwargs[k] = v
 
-    constructor = set if _safe_issubclass(origin, set) else list
-
-    if len(args) == 1 and _safe_issubclass(args[0], BaseModel):
-        return constructor([construct_model_recursive(args[0], item) for item in payload])  # pyright: ignore [reportUnknownVariableType, reportCallIssue]
-
-    return payload
+    return Field(**kwargs)
 
 
-def _construct_object(annotation: type[Any], payload: dict[str, Any]) -> Any:
+def _default_value_from_annotation(annotation: type[Any]) -> Any:
+    try:
+        # Trying to see if the object is instantiable with no value
+        return annotation()
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to get default value from annotation", exc_info=True)
+    # Fallback to None
+    return None
+
+
+def _optional_annotation(annotation: type[Any]) -> type[Any]:
     if _safe_issubclass(annotation, BaseModel):
-        return construct_model_recursive(annotation, payload)  # pyright: ignore [reportUnknownVariableType, reportArgumentType]
+        return partial_model(annotation)
 
-    # Try to map dict of objects
     origin = get_origin(annotation)
-    if not origin or not _safe_issubclass(origin, Mapping):
-        return payload
-
     args = get_args(annotation)
-    if len(args) != 2:
-        return payload
+    if not origin or not args:
+        return annotation
 
-    key_type, value_type = args
-    if key_type is not str:
-        return payload
-    return {k: _construct_for_annotation(value_type, v) for k, v in payload.items()}
+    if _safe_issubclass(origin, Sequence) or _safe_issubclass(origin, set):
+        if not len(args) == 1:
+            raise ValueError("Sequence must have exactly one argument")
+        return origin[_optional_annotation(args[0])]
+        # No need to do anything here ?
 
+    if _safe_issubclass(origin, Mapping):
+        if not len(args) == 2:
+            raise ValueError("Mapping must have exactly two arguments")
+        if args[0] is not str:
+            raise ValueError("Mapping key must be a string")
 
-def _construct_for_annotation(annotation: Optional[type[Any]], payload: Any) -> Any:
-    if annotation is None:
-        return payload
-
-    if isinstance(payload, dict):
-        return _construct_object(annotation, payload)  # pyright: ignore [reportUnknownArgumentType]
-    if isinstance(payload, list):
-        return _construct_list(annotation, payload)  # pyright: ignore [reportUnknownArgumentType]
-
-    return payload
+        return origin[args[0], _optional_annotation(args[1])]
+    return annotation
 
 
-# It does not look like there is an easy way to construct models from partial json objects
-# - https://github.com/team23/pydantic-partial uses a heavy approach by constructing a new dynamic
-# model class with non required fields
-# - partial validation https://docs.pydantic.dev/latest/concepts/experimental/#partial-validation
-# handles partial jsons but still validates that each field is present so it fails in our case
-# where we just want to handle missing fields
-def construct_model_recursive(model: type[BM], payload: dict[str, Any]) -> BM:
-    """
-    Recursively calls model construct to build a model from partial json object
-    """
-    mapped: dict[str, Any] = {}
-    for k, v in payload.items():
-        field = model.model_fields[k]
-        mapped[k] = _construct_for_annotation(field.annotation, v)
-    return model.model_construct(None, **mapped)
+def partial_model(base: type[BM]) -> type[BM]:
+    default_fields: dict[str, tuple[type[Any], FieldInfo]] = {}
+    for name, field in base.model_fields.items():
+        if field.default != PydanticUndefined or field.default_factory or not field.annotation:
+            # No need to do anything here, the field is already optional
+            continue
+
+        overrides: dict[str, Any] = {}
+        try:
+            annotation = _optional_annotation(field.annotation)
+            overrides["annotation"] = annotation
+            overrides["default"] = _default_value_from_annotation(annotation)
+        except Exception:  # noqa: BLE001
+            logger.debug("Failed to make annotation optional", exc_info=True)
+            continue
+
+        default_fields[name] = (annotation, _copy_field_info(field, **overrides))
+
+    if not default_fields:
+        return base
+
+    def custom_eq(o1: BM, o2: Any):
+        if not isinstance(o2, base):
+            return False
+        return o1.model_dump() == o2.model_dump()
+
+    return create_model(  # pyright: ignore [reportCallIssue, reportUnknownVariableType]
+        f"Partial{base.__name__}",
+        __base__=base,
+        __eq__=custom_eq,
+        __hash__=base.__hash__,
+        **default_fields,  # pyright: ignore [reportArgumentType]
+    )

--- a/workflowai/core/utils/_pydantic_test.py
+++ b/workflowai/core/utils/_pydantic_test.py
@@ -1,0 +1,123 @@
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from workflowai.core.utils._pydantic import construct_model_recursive
+
+
+class TestConstructModelRecursive:
+    def test_simple_model(self):
+        class SimpleModel(BaseModel):
+            name1: str
+            name2: str
+
+        constructed = construct_model_recursive(SimpleModel, {"name1": "John"})
+        assert isinstance(constructed, SimpleModel)
+        assert constructed.name1 == "John"
+        with pytest.raises(AttributeError):
+            _ = constructed.name2
+
+    def test_list_of_strings(self):
+        class ListOfStrings(BaseModel):
+            strings: list[str]
+
+        constructed = construct_model_recursive(ListOfStrings, {"strings": ["a", "b"]})
+        assert isinstance(constructed, ListOfStrings)
+        assert constructed.strings == ["a", "b"]
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {},
+            {"field1": "hello"},
+            {"nested": {"name": "hello", "field2": "world"}},
+            {"nested": {"name": "hello"}},
+        ],
+    )
+    def test_nested_model(self, payload: dict[str, Any]):
+        class NestedModel(BaseModel):
+            name: str
+            field2: str
+
+        class OuterModel(BaseModel):
+            field1: str
+            nested: NestedModel
+
+        constructed = construct_model_recursive(OuterModel, payload)
+        assert isinstance(constructed, OuterModel), "constructed is not an instance of OuterModel"
+        if "field1" in payload:
+            assert isinstance(constructed.field1, str), "field1 is not a string"
+        else:
+            with pytest.raises(AttributeError):
+                _ = constructed.field1
+
+        if "nested" in payload:
+            assert isinstance(constructed.nested, NestedModel), "nested is not an instance of NestedModel"
+            if "name" in payload["nested"]:
+                assert isinstance(constructed.nested.name, str)
+            else:
+                with pytest.raises(AttributeError):
+                    _ = constructed.nested.name
+
+            if "field2" in payload["nested"]:
+                assert isinstance(constructed.nested.field2, str)
+            else:
+                with pytest.raises(AttributeError):
+                    _ = constructed.nested.field2
+        else:
+            with pytest.raises(AttributeError):
+                _ = constructed.nested
+
+    def test_list_of_models(self):
+        class NestedModel(BaseModel):
+            name: str
+            field2: str
+
+        class ListOfModels(BaseModel):
+            models: list[NestedModel]
+
+        constructed = construct_model_recursive(
+            ListOfModels,
+            {"models": [{"name": "hello", "field2": "world"}, {"name": "hello"}]},
+        )
+        assert isinstance(constructed, ListOfModels)
+        assert isinstance(constructed.models, list)
+        assert isinstance(constructed.models[0], NestedModel)
+        assert isinstance(constructed.models[1], NestedModel)
+
+    def test_set_of_models(self):
+        class NestedModel(BaseModel):
+            name: str = "1"
+            field2: str
+
+            def __hash__(self) -> int:
+                return hash(self.name)
+
+        class SetOfModels(BaseModel):
+            models: set[NestedModel]
+
+        constructed = construct_model_recursive(
+            SetOfModels,
+            {"models": [{"name": "hello", "field2": "world"}, {"name": "hello"}]},
+        )
+        assert isinstance(constructed, SetOfModels)
+        assert isinstance(constructed.models, set)
+        assert all(isinstance(model, NestedModel) for model in constructed.models)
+
+    def test_dict_of_models(self):
+        class NestedModel(BaseModel):
+            name: str
+            field2: str
+
+        class DictOfModels(BaseModel):
+            models: dict[str, NestedModel]
+
+        constructed = construct_model_recursive(
+            DictOfModels,
+            {"models": {"hello": {"name": "hello", "field2": "world"}, "hello2": {"name": "hello"}}},
+        )
+        assert isinstance(constructed, DictOfModels)
+        assert isinstance(constructed.models, dict)
+        assert isinstance(constructed.models["hello"], NestedModel)
+        assert isinstance(constructed.models["hello2"], NestedModel)


### PR DESCRIPTION
Found an issue with autopilot where we were streaming dictionaries instead of pydantic objects when the output had nested objects.

The issue was undetected until now because:
- we don't have nested objects when streaming in our internal use
- autopilot did test with nested objects but because we did not have type annotations until https://github.com/WorkflowAI/autopilot/pull/14, the code was using a dictionary directly