### PR TITLE
docs: add API key setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,3 +178,7 @@ For advanced workflow patterns and examples, please refer to the [Workflows READ
 ## Contributing
 
 See the [CONTRIBUTING.md](./CONTRIBUTING.md) file for more details. Thank you!
+
+## Acknowledgments
+
+Thanks to [ell](https://github.com/MadcowD/ell) for the inspiration! ✨

--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ This SDK is designed for Python teams who prefer code-first development. It prov
 pip install workflowai
 ```
 
+### API Key
+
+To get started quickly, get an API key from [WorkflowAI Cloud](https://workflowai.com/organization/settings/api-keys). For maximum control over your data, you can also use your [self-hosted instance](https://github.com/WorkflowAI/workflowai), though this requires additional setup time.
+
+Then, set the `WORKFLOWAI_API_KEY` environment variable:
+
+```sh
+export WORKFLOWAI_API_KEY="your-api-key"
+```
+
+### First Agent
+
 Here's a simple example of a WorkflowAI agent that extracts structured flight information from email content:
 
 


### PR DESCRIPTION
@guillaq when I was working on the Google Colab file this afternoon, I realized that we were missing in the `README` the instructions on how to setup the API key.